### PR TITLE
add .env

### DIFF
--- a/prototip/MetaTune/.env.example
+++ b/prototip/MetaTune/.env.example
@@ -1,0 +1,6 @@
+POSTGRES_CONNECTION_STRING=Host={HOST}; Database={DB NAME}; Username={USERNAME}; Password={PASSWORD}; SSL Mode=VerifyFull; Channel Binding=Require;
+EMAIL_SERVER=smtp.gmail.com
+EMAIL_PORT=587
+EMAIL_ADDRESS=lang.lang.team.12@gmail.com
+EMAIL_PASSWORD=
+EMAIL_DISPLAY_NAME=LangLang | Language Learning School


### PR DESCRIPTION
This pull request adds a new `.env.example` file to the `prototip/MetaTune` directory to provide environment variable templates for database and email configuration. This will help developers set up their local environment more easily.

Environment variable templates:

* Added example `POSTGRES_CONNECTION_STRING` for configuring PostgreSQL database connections.
* Added example email server settings, including `EMAIL_SERVER`, `EMAIL_PORT`, `EMAIL_ADDRESS`, `EMAIL_PASSWORD`, and `EMAIL_DISPLAY_NAME`.